### PR TITLE
Batch file writes in StoreService.Save() using StreamWriter

### DIFF
--- a/Collox/Services/StoreService.cs
+++ b/Collox/Services/StoreService.cs
@@ -129,9 +129,10 @@ internal class StoreService : IStoreService
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(fn)!);
+            using var writer = new StreamWriter(fn, append: true);
             while (q.TryDequeue(out var line))
             {
-                File.AppendAllText(fn, line + Environment.NewLine);
+                writer.WriteLine(line);
             }
             lastSave = DateTime.Now;
             Logger.Debug("File saved successfully: {FileName}", fn);


### PR DESCRIPTION
File.AppendAllText opens, writes, and closes the file on every single dequeued line. Replace with a single StreamWriter that stays open for the entire save operation, drastically reducing file I/O overhead.