### PR TITLE
Fix McpService bugs and improve async initialization

### DIFF
--- a/Collox/Common/QueueTransport.cs
+++ b/Collox/Common/QueueTransport.cs
@@ -35,11 +35,12 @@ internal class QueueTransport : ITransport
 
     private readonly ChannelWriter<JsonRpcMessage> messageWriter;
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-
-        messageWriter.Complete();
-        await MessageReader.Completion.ConfigureAwait(false);
+        // Complete both channels so neither side blocks waiting for the other.
+        serverQueue.Writer.TryComplete();
+        clientQueue.Writer.TryComplete();
+        return ValueTask.CompletedTask;
     }
 
     public async Task SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default)


### PR DESCRIPTION
- GetTools() was calling every registered MCP tool with empty arguments on every AI message. Remove the foreach loop that executes tools; GetTools() should only list them.
- Replace .Result in constructor with async factory method to avoid potential deadlock in UI application context.
- Log MCP server startup failures instead of silently swallowing them.