### PR TITLE
Fix null reference crashes across multiple components

### DIFF
--- a/Collox/Services/AIService.cs
+++ b/Collox/Services/AIService.cs
@@ -30,8 +30,16 @@ public partial class AIService : IAIService, IDisposable
 
         if (intelligentProcessor.ApiProviderId != Guid.Empty)
         {
-            intelligentProcessor.ClientManager = new ChatClientManager<IntelligenceApiProvider>(
-                Config.ApiProviders.FirstOrDefault(p => p.Id == intelligentProcessor.ApiProviderId));
+            var apiProvider = Config.ApiProviders.FirstOrDefault(p => p.Id == intelligentProcessor.ApiProviderId);
+            if (apiProvider != null)
+            {
+                intelligentProcessor.ClientManager = new ChatClientManager<IntelligenceApiProvider>(apiProvider);
+            }
+            else
+            {
+                Logger.Warning("API provider {ProviderId} not found when adding processor {ProcessorName}",
+                    intelligentProcessor.ApiProviderId, intelligentProcessor.Name);
+            }
         }
         Config.Processors.Add(intelligentProcessor);
 

--- a/Collox/Services/TemplateService.cs
+++ b/Collox/Services/TemplateService.cs
@@ -8,7 +8,7 @@ public class TemplateService : ITemplateService
     private readonly string templatesDir = Path.Combine(
         Settings.BaseFolder, "Templates");
 
-    private Dictionary<string, MarkdownTemplate> cache;
+    private Dictionary<string, MarkdownTemplate> cache = new();
 
     public async Task DeleteTemplate(string name)
     {
@@ -41,6 +41,7 @@ public class TemplateService : ITemplateService
 
     public async Task<IDictionary<string, MarkdownTemplate>> LoadTemplates()
     {
+        Directory.CreateDirectory(templatesDir);
         var filenames = Directory.GetFiles(templatesDir);
         Dictionary<string, MarkdownTemplate> templates = [];
         foreach (var filename in filenames)

--- a/Collox/ViewModels/TabWriteViewModel.cs
+++ b/Collox/ViewModels/TabWriteViewModel.cs
@@ -83,7 +83,9 @@ public partial class TabWriteViewModel : ObservableRecipient, ITitleBarAutoSugge
                 Logger.Debug("Updating initial tab with saved data");
                 initialTab.ActiveProcessors.Clear();
                 initialTab.ActiveProcessors.AddRange(
-                    tabContext.ActiveProcessors.ConvertAll(x => procs.FirstOrDefault(p => p.Id == x)));
+                    tabContext.ActiveProcessors
+                        .Select(x => procs.FirstOrDefault(p => p.Id == x))
+                        .Where(p => p != null));
                 initialTab.IsBeeping = tabContext.IsBeeping;
                 initialTab.IsSpeaking = tabContext.IsSpeaking;
                 initialTab.SelectedVoice = tabContext.SelectedVoice;
@@ -101,7 +103,9 @@ public partial class TabWriteViewModel : ObservableRecipient, ITitleBarAutoSugge
                 IsEditing = false
             };
             tabData.ActiveProcessors.AddRange(
-                tabContext.ActiveProcessors.ConvertAll(x => procs.FirstOrDefault(p => p.Id == x)));
+                tabContext.ActiveProcessors
+                    .Select(x => procs.FirstOrDefault(p => p.Id == x))
+                    .Where(p => p != null));
 
             Tabs.Add(tabData);
             tabContexts[tabData] = tabContext;


### PR DESCRIPTION
- IntelligentProcessor.Work(): guard against null ClientManager and null Process delegate instead of crashing via `await null`
- AIService.Add(): check FirstOrDefault result before passing to ChatClientManager constructor (which throws on null)
- TemplateService: initialize cache to empty dictionary (was null), and create templates directory before listing files
- TabWriteViewModel.LoadTabs(): filter out null results from FirstOrDefault when resolving saved processor IDs