### PR TITLE
Fix misc bugs: Interlocked bool, null Name crash, default ModelId typo

### DIFF
--- a/Collox/App.xaml.cs
+++ b/Collox/App.xaml.cs
@@ -105,7 +105,7 @@ public partial class App : Application
     public INavigationServiceEx NavigationService => GetService<INavigationServiceEx>();
     public IThemeService ThemeService => GetService<IThemeService>();
 
-    private bool isClosing;
+    private int _isClosing;
 
     public static T GetService<T>() where T : class
     {
@@ -276,7 +276,7 @@ public partial class App : Application
 
             mirrorWindow.Closed += (sender, args) =>
             {
-                if (Current.isClosing) return;
+                if (Volatile.Read(ref Current._isClosing) != 0) return;
                 Logger.Information("Hiding mirror window instead of closing");
                 mirrorWindow.Hide();
                 args.Handled = true;
@@ -400,7 +400,7 @@ public partial class App : Application
 
     private void MainWindow_VisibilityChanged(object sender, WindowVisibilityChangedEventArgs args)
     {
-        if (isClosing)
+        if (Volatile.Read(ref _isClosing) != 0)
         {
             return;
         }
@@ -432,7 +432,7 @@ public partial class App : Application
             Logger.Information("Application state saved successfully");
 
             Logger.Debug("Setting application closing flag");
-            Interlocked.Exchange(ref isClosing, true);
+            Interlocked.Exchange(ref _isClosing, 1);
 
             Logger.Debug("Closing mirror window if initialized");
             if (_lazyMirrorWindow.IsValueCreated)

--- a/Collox/ViewModels/Settings/AISettingsViewModel.cs
+++ b/Collox/ViewModels/Settings/AISettingsViewModel.cs
@@ -94,7 +94,7 @@ public partial class AISettingsViewModel : ObservableObject, IDisposable
         var synonymsEnhancerProcessor = new IntelligentProcessor()
         {
             Id = Guid.NewGuid(),
-            ModelId = " default",
+            ModelId = "default",
             Prompt = prompt,
             Target = Target.Comment,
             FallbackId = Guid.NewGuid(),

--- a/Collox/ViewModels/TemplatesViewModel.cs
+++ b/Collox/ViewModels/TemplatesViewModel.cs
@@ -70,7 +70,7 @@ public partial class TemplatesViewModel : ObservableObject, IDisposable
     [RelayCommand]
     public async Task SaveTemplate()
     {
-        if (Name.IsWhiteSpace() || Name?.Length == 0)
+        if (string.IsNullOrWhiteSpace(Name))
         {
             return;
         }


### PR DESCRIPTION
- App.xaml.cs: change isClosing from bool to int so Interlocked.Exchange compiles (no bool overload exists)
- TemplatesViewModel.SaveTemplate(): replace Name.IsWhiteSpace() (crashes when null) with string.IsNullOrWhiteSpace(Name)
- AISettingsViewModel: remove leading space from default ModelId (" default" → "default")