### PR TITLE
Fix plugin system: init lifecycle, dedup loading, add IDisposable

### DIFF
--- a/Collox.Api/IApiProvider.cs
+++ b/Collox.Api/IApiProvider.cs
@@ -1,13 +1,12 @@
-// Collox.Api, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-// Collox.Api.IApiProvider
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Collox.Api;
 using Microsoft.Extensions.AI;
 
-public interface IApiProvider : IPlugin
-{
-	Task<IEnumerable<string>> GetModelsAsync(ConnectionInfo connectionInfo);
+namespace Collox.Api;
 
-	IChatClient GetClient(ConnectionInfo connectionInfo, string modelId);
+public interface IApiProvider
+{
+    Task<IEnumerable<string>> GetModelsAsync(ConnectionInfo connectionInfo);
+
+    IChatClient GetClient(ConnectionInfo connectionInfo, string modelId);
 }

--- a/Collox/Services/IPluginService.cs
+++ b/Collox/Services/IPluginService.cs
@@ -4,7 +4,16 @@ namespace Collox.Services;
 
 public interface IPluginService
 {
+    /// <summary>
+    /// Phase 1: Discover and load plugin assemblies without initializing them.
+    /// </summary>
     Task LoadPluginsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Phase 2: Initialize all loaded plugins that implement IPlugin.
+    /// </summary>
+    Task InitializePluginsAsync(CancellationToken cancellationToken = default);
+
     IReadOnlyCollection<Plugin> GetLoadedPlugins();
     Task UnloadPluginAsync(string pluginName, CancellationToken cancellationToken = default);
 }

--- a/Collox/Services/IPluginService.cs
+++ b/Collox/Services/IPluginService.cs
@@ -2,7 +2,7 @@
 
 namespace Collox.Services;
 
-public interface IPluginService
+public interface IPluginService : IAsyncDisposable
 {
     /// <summary>
     /// Phase 1: Discover and load plugin assemblies without initializing them.

--- a/Collox/Services/PluginService.cs
+++ b/Collox/Services/PluginService.cs
@@ -28,11 +28,14 @@ public class PluginLoadContext : AssemblyLoadContext
     }
 }
 
-public class PluginService : IPluginService, IDisposable
+public class PluginService : IPluginService
 {
     private readonly IServiceProvider _services;
     private readonly ILogger<PluginService> _logger;
     private readonly Dictionary<string, (Plugin Plugin, PluginLoadContext Context)> _loadedPlugins = new();
+    // Guards all reads/writes to _loadedPlugins to prevent concurrent-access races
+    // between LoadPluginsAsync (background Task.Run) and DisposeAsync (UI-thread shutdown).
+    private readonly SemaphoreSlim _pluginsLock = new(1, 1);
     private readonly string _pluginsDirectory;
     private bool _disposed;
 
@@ -62,7 +65,8 @@ public class PluginService : IPluginService, IDisposable
                 var depsJson = Path.ChangeExtension(dll, ".deps.json");
                 if (File.Exists(depsJson))
                 {
-                    TryLoadPlugin(dll);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    TryLoadPlugin(dll, cancellationToken);
                 }
             }
         }
@@ -70,7 +74,8 @@ public class PluginService : IPluginService, IDisposable
         // Also load simple plugins (single DLLs) from the root plugins directory
         foreach (var pluginPath in Directory.GetFiles(_pluginsDirectory, "*.dll", SearchOption.TopDirectoryOnly))
         {
-            TryLoadPlugin(pluginPath);
+            cancellationToken.ThrowIfCancellationRequested();
+            TryLoadPlugin(pluginPath, cancellationToken);
         }
     }
 
@@ -79,7 +84,20 @@ public class PluginService : IPluginService, IDisposable
     /// </summary>
     public async Task InitializePluginsAsync(CancellationToken cancellationToken = default)
     {
-        foreach (var (name, (plugin, _)) in _loadedPlugins)
+        // Snapshot the current entries under the lock so we don't hold the lock
+        // across the async InitializeAsync calls.
+        List<(string Name, Plugin Plugin)> snapshot;
+        await _pluginsLock.WaitAsync(cancellationToken);
+        try
+        {
+            snapshot = _loadedPlugins.Values.Select(e => (e.Plugin.Name, e.Plugin)).ToList();
+        }
+        finally
+        {
+            _pluginsLock.Release();
+        }
+
+        foreach (var (name, plugin) in snapshot)
         {
             if (plugin.InitPlugin != null)
             {
@@ -96,7 +114,7 @@ public class PluginService : IPluginService, IDisposable
         }
     }
 
-    private void TryLoadPlugin(string dllPath)
+    private void TryLoadPlugin(string dllPath, CancellationToken cancellationToken = default)
     {
         PluginLoadContext loadContext = null;
         try
@@ -121,20 +139,6 @@ public class PluginService : IPluginService, IDisposable
                 Description = pluginAttribute.Description,
             };
 
-            // Check for duplicate before doing any further work
-            if (_loadedPlugins.TryGetValue(plugin.Name, out var existingPluginEntry))
-            {
-                _logger.LogError(
-                    "Plugin name conflict: a plugin named '{PluginName}' is already loaded (Id: {ExistingPluginId}). " +
-                    "The plugin from '{PluginPath}' with Id: {NewPluginId} will not be loaded.",
-                    plugin.Name,
-                    existingPluginEntry.Plugin.Id,
-                    dllPath,
-                    plugin.Id);
-                loadContext.Unload();
-                return;
-            }
-
             // Enumerate types in the assembly
             Type[] allTypes;
             try
@@ -150,9 +154,11 @@ public class PluginService : IPluginService, IDisposable
                     .ToArray();
             }
 
-            // Find optional IPlugin implementation (for plugins that need initialization)
+            // Find optional IPlugin implementation (exclude IApiProvider subtypes so they
+            // don't accidentally match the IPlugin init slot)
             var initPluginType = allTypes
                 .FirstOrDefault(t => typeof(IPlugin).IsAssignableFrom(t)
+                                     && !typeof(IApiProvider).IsAssignableFrom(t)
                                      && !t.IsAbstract && t.IsClass);
             if (initPluginType != null)
             {
@@ -174,7 +180,31 @@ public class PluginService : IPluginService, IDisposable
                 }
             }
 
-            _loadedPlugins[plugin.Name] = (plugin, loadContext);
+            // Register under the lock. Check for duplicates here (not before) so the duplicate
+            // check and the insertion are atomic and can't race with concurrent loads.
+            _pluginsLock.Wait(cancellationToken);
+            try
+            {
+                if (_loadedPlugins.TryGetValue(plugin.Name, out var existingPluginEntry))
+                {
+                    _logger.LogError(
+                        "Plugin name conflict: a plugin named '{PluginName}' is already loaded (Id: {ExistingPluginId}). " +
+                        "The plugin from '{PluginPath}' with Id: {NewPluginId} will not be loaded.",
+                        plugin.Name,
+                        existingPluginEntry.Plugin.Id,
+                        dllPath,
+                        plugin.Id);
+                    loadContext.Unload();
+                    return;
+                }
+
+                _loadedPlugins[plugin.Name] = (plugin, loadContext);
+            }
+            finally
+            {
+                _pluginsLock.Release();
+            }
+
             _logger.LogInformation("Loaded plugin: {PluginName} v{PluginVersion} by {PluginAuthor}",
                 plugin.Name, plugin.Version, plugin.Author);
         }
@@ -186,42 +216,78 @@ public class PluginService : IPluginService, IDisposable
         }
     }
 
-    public IReadOnlyCollection<Plugin> GetLoadedPlugins() =>
-        _loadedPlugins.Values.Select(p => p.Plugin).ToList();
-
-    public async Task UnloadPluginAsync(string pluginName, CancellationToken cancellationToken = default)
+    public IReadOnlyCollection<Plugin> GetLoadedPlugins()
     {
-        if (_loadedPlugins.TryGetValue(pluginName, out var pluginInfo))
+        _pluginsLock.Wait();
+        try
         {
-            if (pluginInfo.Plugin.InitPlugin != null)
-            {
-                await pluginInfo.Plugin.InitPlugin.ShutdownAsync(cancellationToken);
-            }
-            pluginInfo.Context.Unload();
-            _loadedPlugins.Remove(pluginName);
-            _logger.LogInformation("Unloaded plugin: {PluginName}", pluginName);
+            return _loadedPlugins.Values.Select(p => p.Plugin).ToList();
+        }
+        finally
+        {
+            _pluginsLock.Release();
         }
     }
 
-    public void Dispose()
+    public async Task UnloadPluginAsync(string pluginName, CancellationToken cancellationToken = default)
     {
-        if (_disposed)
-            return;
-
-        foreach (var (name, (plugin, context)) in _loadedPlugins)
+        await _pluginsLock.WaitAsync(cancellationToken);
+        try
         {
-            try
+            if (!_loadedPlugins.TryGetValue(pluginName, out var pluginInfo))
+                return;
+
+            // Remove first so the entry is gone even if ShutdownAsync throws
+            _loadedPlugins.Remove(pluginName);
+
+            if (pluginInfo.Plugin.InitPlugin != null)
             {
-                plugin.InitPlugin?.ShutdownAsync().GetAwaiter().GetResult();
-                context.Unload();
-                _logger.LogInformation("Shut down plugin: {PluginName}", name);
+                // Run on a thread-pool thread to avoid deadlocking the caller's sync context
+                await Task.Run(() => pluginInfo.Plugin.InitPlugin.ShutdownAsync(cancellationToken), cancellationToken);
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error shutting down plugin: {PluginName}", name);
-            }
+
+            pluginInfo.Context.Unload();
+            _logger.LogInformation("Unloaded plugin: {PluginName}", pluginName);
         }
-        _loadedPlugins.Clear();
+        finally
+        {
+            _pluginsLock.Release();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
         _disposed = true;
+
+        await _pluginsLock.WaitAsync();
+        try
+        {
+            foreach (var (name, (plugin, context)) in _loadedPlugins)
+            {
+                try
+                {
+                    if (plugin.InitPlugin != null)
+                    {
+                        // Run on a thread-pool thread to avoid deadlocking the UI sync context
+                        await Task.Run(() => plugin.InitPlugin.ShutdownAsync(CancellationToken.None));
+                    }
+
+                    context.Unload();
+                    _logger.LogInformation("Shut down and unloaded plugin: {PluginName}", name);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error shutting down plugin: {PluginName}", name);
+                }
+            }
+
+            _loadedPlugins.Clear();
+        }
+        finally
+        {
+            _pluginsLock.Release();
+            _pluginsLock.Dispose();
+        }
     }
 }

--- a/Collox/Services/PluginService.cs
+++ b/Collox/Services/PluginService.cs
@@ -238,10 +238,17 @@ public class PluginService : IPluginService
             // Remove first so the entry is gone even if ShutdownAsync throws
             _loadedPlugins.Remove(pluginName);
 
-            if (pluginInfo.Plugin.InitPlugin != null)
+            try
             {
-                // Run on a thread-pool thread to avoid deadlocking the caller's sync context
-                await Task.Run(() => pluginInfo.Plugin.InitPlugin.ShutdownAsync(cancellationToken), cancellationToken);
+                if (pluginInfo.Plugin.InitPlugin != null)
+                {
+                    // Run on a thread-pool thread to avoid deadlocking the caller's sync context
+                    await Task.Run(() => pluginInfo.Plugin.InitPlugin.ShutdownAsync(cancellationToken), cancellationToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error shutting down plugin: {PluginName}", pluginName);
             }
 
             pluginInfo.Context.Unload();

--- a/Collox/Services/PluginService.cs
+++ b/Collox/Services/PluginService.cs
@@ -154,11 +154,9 @@ public class PluginService : IPluginService
                     .ToArray();
             }
 
-            // Find optional IPlugin implementation (exclude IApiProvider subtypes so they
-            // don't accidentally match the IPlugin init slot)
+            // Find optional IPlugin implementation (for plugins that need initialization)
             var initPluginType = allTypes
                 .FirstOrDefault(t => typeof(IPlugin).IsAssignableFrom(t)
-                                     && !typeof(IApiProvider).IsAssignableFrom(t)
                                      && !t.IsAbstract && t.IsClass);
             if (initPluginType != null)
             {


### PR DESCRIPTION
## Summary
- **Decouple `IApiProvider` from `IPlugin`**: `IApiProvider` no longer extends `IPlugin`. API providers just provide models/clients — they don't need init/shutdown lifecycle. `IPlugin` is only for types that need initialization.
- **Two-phase plugin lifecycle**: `LoadPluginsAsync` (Phase 1) discovers and loads plugin assemblies without calling `InitializeAsync`. `InitializePluginsAsync` (Phase 2) initializes all loaded plugins that implement `IPlugin`. Both are called from `App.OnLaunched`.
- **`LoadPluginsAsync` was never called**: Added background startup call in `App.OnLaunched`.
- **~90 lines of duplicated code**: The subdirectory and root-directory plugin loading paths were near-identical copies. Extracted into a shared `TryLoadPlugin` method.
- **Missing `IDisposable`**: `PluginService` used collectible `AssemblyLoadContext` but never unloaded them or called `ShutdownAsync`. Now implements `IDisposable` with proper cleanup, called during app shutdown.
- **Load context leaked on failure**: If plugin loading threw after creating a `PluginLoadContext`, the context was never unloaded. Added cleanup in the catch block.

## Test plan
- [ ] Verify plugins in subdirectories (with deps.json) load correctly
- [ ] Verify single-DLL plugins in root plugins directory load correctly
- [ ] Confirm `IPlugin.InitializeAsync` is called in Phase 2, not during loading
- [ ] Confirm `IApiProvider` implementations work without implementing `IPlugin`
- [ ] Verify duplicate plugin names are rejected with proper error logging
- [ ] Verify app shutdown calls `ShutdownAsync` + `Unload` on all loaded plugins
- [ ] Verify plugin load failures don't leak `AssemblyLoadContext`

🤖 Generated with [Claude Code](https://claude.com/claude-code)